### PR TITLE
add "on delete cascade" to header-record FK in order to delete records

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 rootProject.name = 'kafka-triage'
 
 gradle.rootProject {
-    version = '0.2.1-SNAPSHOT'
+    version = '0.2.2-SNAPSHOT'
 }

--- a/src/main/resources/db/migration/V0.2.2__alter_constraint_add_delete_cascade.sql
+++ b/src/main/resources/db/migration/V0.2.2__alter_constraint_add_delete_cascade.sql
@@ -1,0 +1,6 @@
+alter table header
+drop constraint fk_record,
+add constraint fk_record
+   foreign key (record_id)
+   references record
+   on delete cascade;


### PR DESCRIPTION
In order to delete records, either manual of automatically in the future, add cascade delete to foreign key constraint so you can now run the query:

`DELETE FROM record where triaged=true;`